### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Dictionary.
 ## Cookbook
 
 ### Run RepeatModeler
-*RepeatModeler will produce concensus sequeces representing clusters of denovo
+*RepeatModeler will produce consensus sequeces representing clusters of denovo
 repeat sequences, partialy classified by RepeatMasker*
 
 <pre>


### PR DESCRIPTION
@HullUni-bioinformatics, I've corrected a typographical error in the documentation of the [TE-search-tools](https://github.com/HullUni-bioinformatics/TE-search-tools) project. Specifically, I've changed concensus to consensus. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
